### PR TITLE
Change the default k to 64, add 32 and 96

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
-default: abyss-pe k=25 name=genome in=${READS}
-k-64: abyss-pe k=64 name=genome in=${READS}
+k-32: abyss-pe k=32 name=genome in=${READS}
+default: abyss-pe k=64 name=genome in=${READS}
+k-96: abyss-pe k=96 name=genome in=${READS}


### PR DESCRIPTION
Hi, Michael. The default value of k of 25 is much too low for most data sets. This patch increases the default value of k to 64, and adds 32 and 96 as low- and high-k alternatives. We're looking into integrating KmerGenie or similar into the ABySS docker file. Have you considered integrating a k-choosing tool into Nucleotid.es upstream of all dBG assemblers?

This patch replaces #1—though I prefer #1 if you'll consider it, as it's more similar to our typical workflow with ABySS.
